### PR TITLE
Added mousedown triggering for plugins

### DIFF
--- a/jquery.tileviewer.js
+++ b/jquery.tileviewer.js
@@ -848,6 +848,13 @@ var methods = {
                     var x = e.pageX - offset.left;
                     var y = e.pageY - offset.top;
 
+                    for(var i=0;i<view.plugins.length; i++) {
+                        var plugin = view.plugins[i];
+                        if(plugin.onmousedown) {
+                            plugin.onmousedown.call(plugin, view, e, x, y);
+                        }
+                    }
+
                     if(e.button != 2) { //not right button
                         view.mousedown = true;
 


### PR DESCRIPTION
Found that mousedown events were not being detected by plugins.  Added this and tested.  Not sure if the plugin calls should go before or after the main tileviewer mousedown selection functions.  
